### PR TITLE
Replace literals with variable basenames

### DIFF
--- a/standard/Makefile
+++ b/standard/Makefile
@@ -2,13 +2,13 @@ FILE_BASENAME=volume_i4
 OUTDIR=../compiled_docs/
 
 html:
-	asciidoctor --trace -o ${OUTDIR}${FILE_BASENAME}.html volume_i4.adoc
+	asciidoctor --trace -o ${OUTDIR}${FILE_BASENAME}.html ${FILE_BASENAME}.adoc
 
 pdf:
-	asciidoctor --trace -r asciidoctor-pdf --trace -b pdf -o ${OUTDIR}${FILE_BASENAME}.pdf volume_i4.adoc
+	asciidoctor --trace -r asciidoctor-pdf --trace -b pdf -o ${OUTDIR}${FILE_BASENAME}.pdf ${FILE_BASENAME}.adoc
 
 docx:
-	asciidoctor --trace --backend docbook --out-file - volume_i4.adoc | pandoc --from docbook --to docx --output ${OUTDIR}${FILE_BASENAME}.docx
+	asciidoctor --trace --backend docbook --out-file - ${FILE_BASENAME}.adoc | pandoc --from docbook --to docx --output ${OUTDIR}${FILE_BASENAME}.docx
 
 linkcheck:
 	find . -name "???.adoc" -exec asciidoc-link-check -p -c ./asciidoc-link-check-config.json {} \;


### PR DESCRIPTION
Saw there was a mix of literals and variables in filenames, this would cause us trouble down the road